### PR TITLE
add-https-nextjs-org-under-frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@
 <!-- CATEGORY ANCHORS START -->
 ### Categories
 - [JavaScript Frameworks](#javascript-frameworks)
+- [Frameworks](#frameworks)
 <!-- CATEGORY ANCHORS END -->
 
 ### JavaScript Frameworks
 - [React](https://react.dev): React is a JavaScript library for building user interfaces using components, enabling developers to create web and native apps efficiently. It supports interactivity, integrates with frameworks like Next.js, and fosters a global community. React's architecture allows seamless data fetching and rendering across platforms, enhancing user experience.
+
+### Frameworks
+- [Next.js](https://nextjs.org): Next.js framework


### PR DESCRIPTION
Added Next.js under Frameworks category. Reference: https://nextjs.org 