### PR TITLE
add-https---n8n-io-under-workflow-automation-platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # AIggregator
 
 ## Table of Contents
-
-<!-- CATEGORY ANCHORS START -->
-### Categories
 - [AI Platforms](#ai-platforms)
 - [JavaScript Frameworks](#javascript-frameworks)
-<!-- CATEGORY ANCHORS END -->
+- [Workflow Automation Platforms](#workflow-automation-platforms)
 
 ### AI Platforms
 - [i10X](https://i10x.ai/): i10X is an AI marketplace offering access to over 500 specialized AI agents and top models for diverse tasks, including creativity, marketing, design, and productivity. It provides these tools at a competitive subscription rate, ensuring high-quality performance with expert-designed functionalities for various applications.
 
 ### JavaScript Frameworks
 - [React](https://react.dev): React is a JavaScript library for building user interfaces using components, enabling developers to create web and native apps efficiently. It supports interactivity, integrates with frameworks like Next.js, and fosters a global community. React's architecture allows seamless data fetching and rendering across platforms, enhancing user experience.
+
+### Workflow Automation Platforms
+- [n8n.io](https://n8n.io): n8n.io is a flexible AI workflow automation platform providing technical teams with tools to build multi-step agents, integrate over 500 apps, and self-host AI models. Offering both code and drag-n-drop capabilities, it streamlines operations across IT, security, sales, and more, enhancing productivity and efficiency.


### PR DESCRIPTION
Adds [n8n.io](https://n8n.io) under Workflow Automation Platforms

Tool summary: n8n.io is a flexible AI workflow automation platform providing technical teams with tools to build multi-step agents, integrate over 500 apps, and self-host AI models. Offering both code and drag-n-drop capabilities, it streamlines operations across IT, security, sales, and more, enhancing productivity and efficiency.