### PR TITLE
add-https-dropmagic-ai-under-ecommerce-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 
 ## Table of Contents
 
-<!-- CATEGORY ANCHORS START -->
-### Categories
 - [AI Platforms](#ai-platforms)
+- [eCommerce Tools](#ecommerce-tools)
 - [JavaScript Frameworks](#javascript-frameworks)
-<!-- CATEGORY ANCHORS END -->
 
 ### AI Platforms
 - [i10X](https://i10x.ai/): i10X is an AI marketplace offering access to over 500 specialized AI agents and top models for diverse tasks, including creativity, marketing, design, and productivity. It provides these tools at a competitive subscription rate, ensuring high-quality performance with expert-designed functionalities for various applications.
+
+### eCommerce Tools
+- [Dropmagic](https://dropmagic.ai): Dropmagic is an AI-powered tool that quickly builds eCommerce stores on Shopify by generating store elements like branding, images, and copy from product URLs. It simplifies store setup, optimizing for conversions without requiring design skills, and offers multilingual support, helping users launch stores efficiently and affordably.
 
 ### JavaScript Frameworks
 - [React](https://react.dev): React is a JavaScript library for building user interfaces using components, enabling developers to create web and native apps efficiently. It supports interactivity, integrates with frameworks like Next.js, and fosters a global community. React's architecture allows seamless data fetching and rendering across platforms, enhancing user experience.


### PR DESCRIPTION
Adds [Dropmagic](https://dropmagic.ai) under eCommerce Tools

Tool summary: Dropmagic is an AI-powered tool that quickly builds eCommerce stores on Shopify by generating store elements like branding, images, and copy from product URLs. It simplifies store setup, optimizing for conversions without requiring design skills, and offers multilingual support, helping users launch stores efficiently and affordably.